### PR TITLE
ci: add dependabot for @knapsack/* packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates#enabling-github-dependabot-version-updates
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: 'npm'
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: '/'
+    target-branch: 'main'
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: 'daily'
+    versioning-strategy: 'increase'
+    allow:
+      - dependency-name: '@knapsack/*'


### PR DESCRIPTION
This sets up [Dependabot](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/enabling-and-disabling-version-updates#enabling-github-dependabot-version-updates) to auto create a PR anytime any of the `@knapsack/*` packages of the App Client get an update. 
